### PR TITLE
Correct lat/lon order for Wikipedia (and round all lat/lons to 5 DPs)

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ function updateLatLonFields(lat, lon) {
     document.getElementById("latlon").innerHTML = lat + ', ' + lon;
     document.getElementById("wkt").innerHTML = 'POINT('+lon+' '+lat +')';
     document.getElementById("geojson").innerHTML = '{ "type": "Point", "coordinates": [' + [lon, lat] + '] }';
-    document.getElementById("wikipedia").innerHTML = '{{Coord|' + lon + '|' + lat + '|display=title}}';
+    document.getElementById("wikipedia").innerHTML = '{{Coord|' + lat + '|' + lon + '|display=title}}';
 }
 
 function showMap() {

--- a/index.html
+++ b/index.html
@@ -90,6 +90,8 @@ function timeLoaded(obj) {
 }
 
 function updateLatLonFields(lat, lon) {
+    lat = lat.toFixed(5);
+    lon = lon.toFixed(5);
     document.getElementById("latlon").innerHTML = lat + ', ' + lon;
     document.getElementById("wkt").innerHTML = 'POINT('+lon+' '+lat +')';
     document.getElementById("geojson").innerHTML = '{ "type": "Point", "coordinates": [' + [lon, lat] + '] }';


### PR DESCRIPTION
Sorry, I had the lat/lon order wrong. (I thought the updated commit would automatically be included in the pull request, but I guess not.)
